### PR TITLE
docs: add Colab notebook playground section (#2)

### DIFF
--- a/docs/playground/agents-playground.md
+++ b/docs/playground/agents-playground.md
@@ -1,0 +1,26 @@
+---
+title: Agent Playground (Colab)
+sidebar_position: 2
+---
+
+# Agent Playground (Colab)
+
+Run SynapseKit agents in a **real Python environment** using Google Colab.
+
+## ✅ Open in Colab
+
+[Open Agent Notebook →](https://colab.research.google.com/github/SynapseKit/synapsekit-docs/blob/main/notebooks/agents/react-research-assistant.ipynb)
+
+---
+
+## What you'll learn
+
+- How to create a function-calling agent
+- How tools are wired into an agent
+- How the agent reasons step-by-step
+
+---
+
+**Next:**
+- [Graph Playground (Colab)](./graphs-playground)
+- [RAG Playground (Colab)](./rag-playground)

--- a/docs/playground/graphs-playground.md
+++ b/docs/playground/graphs-playground.md
@@ -1,0 +1,26 @@
+---
+title: Graph Playground (Colab)
+sidebar_position: 3
+---
+
+# Graph Playground (Colab)
+
+Run SynapseKit Graph workflows in a **real Python environment** using Google Colab.
+
+## ✅ Open in Colab
+
+[Open Graph Notebook →](https://colab.research.google.com/github/SynapseKit/synapsekit-docs/blob/main/notebooks/graph/linear-workflow.ipynb)
+
+---
+
+## What you'll learn
+
+- How to build a `StateGraph`
+- How nodes and edges compose workflows
+- How to execute and inspect results
+
+---
+
+**Next:**
+- [Agent Playground (Colab)](./agents-playground)
+- [RAG Playground (Colab)](./rag-playground)

--- a/docs/playground/index.md
+++ b/docs/playground/index.md
@@ -1,0 +1,27 @@
+---
+title: Interactive Notebooks
+sidebar_position: 0
+---
+
+# Interactive Notebooks
+
+These notebooks let you run SynapseKit in a **real Python runtime** via Google Colab.
+
+## ✅ Start Here
+
+- [RAG Playground →](./rag-playground)
+- [Agent Playground →](./agents-playground)
+- [Graph Playground →](./graphs-playground)
+
+---
+
+## Why Colab instead of inline playgrounds?
+
+SynapseKit is a Python framework with real LLM integrations. Browser‑only sandboxes cannot provide a full or reliable experience.
+
+Google Colab gives you:
+- Real Python execution
+- Full SynapseKit API access
+- No local setup
+
+This mirrors how platforms like GeeksforGeeks and major ML docs provide runnable examples.

--- a/docs/playground/rag-playground.md
+++ b/docs/playground/rag-playground.md
@@ -1,0 +1,34 @@
+---
+title: RAG Playground (Colab)
+sidebar_position: 1
+---
+
+# RAG Playground (Colab)
+
+Run SynapseKit's RAG workflow in a **real Python environment** using Google Colab.
+
+This is the most reliable way to experience the full SynapseKit stack without local setup.
+
+## ✅ Open in Colab
+
+[Open RAG Quickstart Notebook →](https://colab.research.google.com/github/SynapseKit/synapsekit-docs/blob/main/notebooks/rag/quickstart-3-lines.ipynb)
+
+---
+
+## What you'll learn
+
+- How to create a `RAGPipeline`
+- How to add documents and ask questions
+- How retrieval + generation works together
+
+## Why Colab?
+
+- Real Python execution
+- Full SynapseKit API (not a mock)
+- No installation required
+
+---
+
+**Next:**
+- [Agent Playground (Colab)](./agents-playground)
+- [Graph Playground (Colab)](./graphs-playground)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -13,6 +13,17 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Interactive Notebooks',
+      link: { type: 'doc', id: 'playground/index' },
+      items: [
+        'playground/index',
+        'playground/rag-playground',
+        'playground/agents-playground',
+        'playground/graphs-playground',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Guides',
       link: { type: 'doc', id: 'guides/index' },
       items: [


### PR DESCRIPTION
## Changes
- Added Interactive Notebooks section with Colab links (RAG, Agents, Graphs)
- Added landing page for the notebooks
- Updated sidebar to surface the new section

Closes #2